### PR TITLE
Provider versions may increment patch 🔼

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -18,11 +18,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run tflint
-        uses: ghcr.io/terraform-linters/tflint
-
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.23.0
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: 'fs'
           scan-ref: .

--- a/provider.tf
+++ b/provider.tf
@@ -17,7 +17,7 @@ terraform {
       version = "3.6.3"
     }
   }
-  required_version = "1.9.0"
+  required_version = "1.9.8"
 }
 
 provider "dockerless" {

--- a/provider.tf
+++ b/provider.tf
@@ -2,22 +2,22 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.56.1"
+      version = "~> 5.56.1"
     }
     dockerless = {
       source  = "nullstone-io/dockerless"
-      version = "0.1.1"
+      version = "~> 0.1.1"
     }
     null = {
       source  = "hashicorp/null"
-      version = "3.2.3"
+      version = "~> 3.2.3"
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.6.3"
+      version = "~> 3.6.3"
     }
   }
-  required_version = "1.9.8"
+  required_version = "~> 1.9.0"
 }
 
 provider "dockerless" {


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- Failed `dibbs-aws` terraform plan due to provider version mismatch: https://github.com/CDCgov/dibbs-aws/actions/runs/11805662379/job/32888627479
- This should fix this issue without restricting the exact patch versions required.
- Trivy version 0.23.0 frequently breaks

## Changes Proposed

- Allow patch versions to increment
- Update Trivy version