### PR TITLE
Allow SSL cert and port 443 setup 🔒 

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -23,7 +23,8 @@ jobs:
         with:
           scan-type: 'fs'
           scan-ref: .
-          scanners: 'vuln,secret,config'
+          scanners: 'vuln,secret,misconfig'
+          skip-dirs: '.cache'
           ignore-unfixed: false
           exit-code: '1'
           format: 'table'

--- a/_output.tf
+++ b/_output.tf
@@ -53,8 +53,12 @@ output "alb_listener_arn" {
   value = aws_alb_listener.http.arn
 }
 
-output "alb_listener_rules_arns" {
-  value = { for rule_name, rule in aws_alb_listener_rule.this : rule_name => rule.arn }
+output "http_alb_listener_rules_arns" {
+  value = { for rule_name, rule in aws_alb_listener_rule.http : rule_name => rule.arn }
+}
+
+output "https_alb_listener_rules_arns" {
+  value = { for rule_name, rule in aws_alb_listener_rule.https : rule_name => rule.arn }
 }
 
 output "ecs_security_group_arn" {

--- a/_variable.tf
+++ b/_variable.tf
@@ -3,6 +3,7 @@ variable "internal" {
   description = "Flag to determine if the several AWS resources are public (intended for external access, public internet) or private (only intended to be accessed within your AWS VPC or avaiable with other means, a transit gateway for example)."
   default     = true
 }
+
 variable "appmesh_name" {
   type        = string
   description = "Name of the AWS App Mesh"
@@ -110,6 +111,12 @@ variable "service_data" {
   }))
   description = "Data for the DIBBS services"
   default     = {}
+}
+
+variable "certificate_arn" {
+  type        = string
+  description = "ARN of the SSL certificate that enables ssl termination on the ALB"
+  default = ""
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
# DEVOPS PULL REQUEST

## Related Issue

- resolve #8 

## Changes Proposed
- **Output Changes:**
  - Renamed `alb_listener_rules_arns` to `http_alb_listener_rules_arns`.
  - Added a new output `https_alb_listener_rules_arns` for HTTPS listener rules.
- **Variable Changes:**
  - Added a new variable `certificate_arn` to manage SSL certificate for ALB.
- **ALB Listener and Rules:**
  - Split `aws_alb_listener_rule.this` into `aws_alb_listener_rule.http` and `aws_alb_listener_rule.https`.
  - Added conditional logic for redirect actions based on the presence of `certificate_arn`.
  - Created a new `aws_alb_listener.https` resource with appropriate SSL settings and default action.
- **Dynamic Actions:**
  - Introduced dynamic `forward` and `redirect` actions based on the presence of `certificate_arn`.
- **New HTTPS Listener Rule:**
  - Added `aws_alb_listener_rule.https` for handling HTTPS paths with SSL termination.