### PR TITLE
ALB path

### DIFF
--- a/_variable.tf
+++ b/_variable.tf
@@ -111,6 +111,7 @@ variable "service_data" {
     host_port      = number
     public         = bool
     registry_url   = string
+    root_service = bool 
     env_vars = list(object({
       name  = string
       value = string
@@ -215,3 +216,5 @@ Iynom6unaheZpS4DFIh2w9UCAwEAAQ==
 -----END PUBLIC KEY-----
           EOT
 }
+
+

--- a/alb.tf
+++ b/alb.tf
@@ -28,7 +28,7 @@ resource "aws_alb_target_group" "this" {
     protocol            = "HTTP"
     matcher             = "200-499"
     timeout             = "3"
-    path                = local.service_data[each.key].root_service ? ["/", "/"] : [["/${each.key}", "/${each.key}/"]]
+    path                = local.service_data[each.key].root_service ? ["/", "/"] : ["/${each.key}", "/${each.key}/"]
     unhealthy_threshold = "3"
   }
   tags = local.tags
@@ -108,7 +108,8 @@ resource "aws_alb_listener_rule" "http" {
 
   condition {
     path_pattern {
-     values = local.service_data[each.key].root_service ? ["/", "/"] : [["/${each.key}", "/${each.key}/"]]
+     values = local.service_data[each.key].root_service ? ["/", "/"] : ["/${each.key}", "/${each.key}/"]
+
     }
   }
   lifecycle {
@@ -152,7 +153,7 @@ resource "aws_alb_listener_rule" "https" {
 
   condition {
     path_pattern {
-      values = local.service_data[each.key].root_service ? ["/", "/"] : [["/${each.key}", "/${each.key}/"]]
+      values = local.service_data[each.key].root_service ? ["/", "/"] : ["/${each.key}", "/${each.key}/"]
     }
   }
   lifecycle {

--- a/alb.tf
+++ b/alb.tf
@@ -28,7 +28,7 @@ resource "aws_alb_target_group" "this" {
     protocol            = "HTTP"
     matcher             = "200-499"
     timeout             = "3"
-    path                = "/${each.key}"
+    path                = local.service_data[each.key].root_service ? ["/", "/"] : [["/${each.key}", "/${each.key}/"]]
     unhealthy_threshold = "3"
   }
   tags = local.tags
@@ -108,7 +108,7 @@ resource "aws_alb_listener_rule" "http" {
 
   condition {
     path_pattern {
-      values = ["/${each.key}", "/${each.key}/*"]
+     values = local.service_data[each.key].root_service ? ["/", "/"] : [["/${each.key}", "/${each.key}/"]]
     }
   }
   lifecycle {
@@ -152,7 +152,7 @@ resource "aws_alb_listener_rule" "https" {
 
   condition {
     path_pattern {
-      values = ["/${each.key}", "/${each.key}/*"]
+      values = local.service_data[each.key].root_service ? ["/", "/"] : [["/${each.key}", "/${each.key}/"]]
     }
   }
   lifecycle {

--- a/alb.tf
+++ b/alb.tf
@@ -108,7 +108,7 @@ resource "aws_alb_listener_rule" "http" {
 
   condition {
     path_pattern {
-     values = local.service_data[each.key].root_service ? ["/", "/"] : ["/${each.key}", "/${each.key}/"]
+     values = local.service_data[each.key].root_service ? ["/", "/"] : ["/${each.key}", "/${each.key}/*"]
 
     }
   }
@@ -153,7 +153,7 @@ resource "aws_alb_listener_rule" "https" {
 
   condition {
     path_pattern {
-      values = local.service_data[each.key].root_service ? ["/", "/"] : ["/${each.key}", "/${each.key}/"]
+      values = local.service_data[each.key].root_service ? ["/", "/"] : ["/${each.key}", "/${each.key}/*"]
     }
   }
   lifecycle {


### PR DESCRIPTION
- Added variable `root_service` to service, in order to allow the path pattern for the alb to be customized based on developers deployment. 
- The default value for this variable should be false so the originally intended path `/${each.key}` is used