### PR TITLE
Cipher parameter for sqlserver 🔏 

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ No modules.
 | <a name="input_cloudmap_namespace_name"></a> [cloudmap\_namespace\_name](#input\_cloudmap\_namespace\_name) | Name of the AWS Cloud Map namespace | `string` | `""` | no |
 | <a name="input_cw_retention_in_days"></a> [cw\_retention\_in\_days](#input\_cw\_retention\_in\_days) | Retention period in days for CloudWatch logs | `number` | `30` | no |
 | <a name="input_database_type"></a> [database\_type](#input\_database\_type) | The type of database to use (postgresql or sqlserver) | `string` | `"postgresql"` | no |
+| <a name="input_db_cipher"></a> [db\_cipher](#input\_db\_cipher) | The cipher to use for the sql server database connection | `string` | `""` | no |
 | <a name="input_dibbs_config_name"></a> [dibbs\_config\_name](#input\_dibbs\_config\_name) | Name of the DIBBS configuration | `string` | `""` | no |
 | <a name="input_dibbs_repo"></a> [dibbs\_repo](#input\_dibbs\_repo) | Name of the DIBBS repository | `string` | `"ghcr.io/cdcgov/dibbs-ecr-viewer"` | no |
 | <a name="input_disable_ecr"></a> [disable\_ecr](#input\_disable\_ecr) | Flag to disable the aws ecr service for docker image storage, defaults to false | `bool` | `false` | no |

--- a/_local.tf
+++ b/_local.tf
@@ -25,6 +25,10 @@ locals {
     name  = "SQL_SERVER_HOST",
     value = var.secrets_manager_sqlserver_host_version
   } : null
+  db_cipher = var.database_type == "sqlserver" ? {
+    name  = "DB_CIPHER",
+    value = var.db_cipher
+  } : null
   service_data = length(var.service_data) > 0 ? var.service_data : {
     ecr-viewer = {
       short_name        = "ecrv",
@@ -69,7 +73,8 @@ locals {
         local.database_url,
         local.sqlserver_user,
         local.sqlserver_password,
-        local.sqlserver_host
+        local.sqlserver_host,
+        local.db_cipher
       ]
     },
     fhir-converter = {

--- a/_variable.tf
+++ b/_variable.tf
@@ -225,3 +225,9 @@ variable "dibbs_repo" {
   description = "Name of the DIBBS repository"
   default     = "ghcr.io/cdcgov/dibbs-ecr-viewer"
 }
+
+variable "db_cipher" {
+  type        = string
+  description = "The cipher to use for the sql server database connection"
+  default     = ""
+}


### PR DESCRIPTION
## Changes Proposed 

- resolves #22 
- This pull request introduces a new optional configuration parameter, "db_cipher," for SQL Server database connections. This addition enables users to specify the cipher to be used for the database connection.

## Additional Information 

- This is a non-breaking change, as it has a default value of an empty string.