### PR TITLE
fix(policy): add KMS permissions and resources

### DIFF
--- a/_data.tf
+++ b/_data.tf
@@ -20,10 +20,14 @@ data "aws_iam_policy_document" "ecr_viewer_s3" {
       "s3:GetObject",
       "s3:GetObjectAcl",
       "s3:ListBucket",
+      "kms:GenerateDataKey",
+      "kms:Decrypt"
     ]
     resources = [
       aws_s3_bucket.ecr_viewer.arn,
       "${aws_s3_bucket.ecr_viewer.arn}/*",
+      aws_kms_key.ecr_viewer.arn,
+      "${aws_kms_key.ecr_viewer.arn}/*",
     ]
   }
 }


### PR DESCRIPTION
Add the KMS permissions to the ecr-viewer s3 policy to enable the app to access storage.