### PR TITLE
feat: add METADATA_DATABASE_MIGRATION_SECRET configuration and variable

### DIFF
--- a/_local.tf
+++ b/_local.tf
@@ -29,6 +29,10 @@ locals {
     name  = "DB_CIPHER",
     value = var.db_cipher
   } : null
+  metadata_database_migration_secret = var.secrets_manager_metadata_database_migration_secret_version != "" ? {
+    name  = "METADATA_DATABASE_MIGRATION_SECRET",
+    value = var.secrets_manager_metadata_database_migration_secret_version
+  } : null
   auth_provider      = var.auth_provider != "" ? { name = "AUTH_PROVIDER", value = var.auth_provider } : null
   auth_client_id     = var.auth_client_id != "" ? { name = "AUTH_CLIENT_ID", value = var.auth_client_id } : null
   auth_client_secret = var.secrets_manager_auth_client_secret_version != "" ? { name = "AUTH_CLIENT_SECRET", value = var.secrets_manager_auth_client_secret_version } : null
@@ -139,6 +143,7 @@ locals {
         local.sqlserver_password,
         local.sqlserver_host,
         local.db_cipher,
+        local.metadata_database_migration_secret,
         local.auth_provider,
         local.auth_client_id,
         local.auth_client_secret,

--- a/_variable.tf
+++ b/_variable.tf
@@ -166,6 +166,12 @@ variable "secrets_manager_sqlserver_host_version" {
   sensitive = true
 }
 
+variable "secrets_manager_metadata_database_migration_secret_version" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
 variable "auth_provider" {
   type        = string
   default     = ""


### PR DESCRIPTION
## Changes Proposed

- Added a new Terraform variable (secrets_manager_metadata_database_migration_secret_version) to manage the metadata database migration secret.
- Updated locals to include a new entry (metadata_database_migration_secret) that derives its value from the new variable if a non-empty value is provided.

## Additional Information

- The new variable uses a default empty string.
- It is marked as sensitive to prevent accidental exposure.

## Testing

- Run a Terraform plan to verify that the new variable does not cause unexpected changes.
- Test by setting the new variable to a non-empty value and ensure the metadata_database_migration_secret local is correctly populated.
- Confirm that the overall configuration output now includes the migration secret when expected.