### PR TITLE
Adding fhir-converter-proxy

### DIFF
--- a/_local.tf
+++ b/_local.tf
@@ -178,7 +178,7 @@ locals {
       short_name        = "fhircp",
       app_repo          = local.dibbs_repo,
       app_image         = var.disable_ecr == false ? "${terraform.workspace}-fhir-converter-proxy" : "fhir-converter-proxy",
-      app_version       = "0.0.0", #TODO laura: Switch this back
+      app_version       = "0.0.1", #TODO laura: Switch this back
       container_port    = 8080,
       host_port         = 8080,
       public            = false,
@@ -284,10 +284,6 @@ locals {
         },
         {
           name  = "FHIR_CONVERTER_URL",
-          value = "http://fhir-converter:8080"
-        },
-        {
-          name = "FHIR_CONVERTER_PROXY_URL",
           value = "http://fhir-converter-proxy:8080"
         },
         {

--- a/_local.tf
+++ b/_local.tf
@@ -58,6 +58,14 @@ locals {
       target_cpu    = try(var.override_autoscaling["fhir-converter"].target_cpu, 50),
       target_memory = try(var.override_autoscaling["fhir-converter"].target_memory, 80)
     },
+    fhir-converter-proxy = {
+      cpu           = try(var.override_autoscaling["fhir-converter-proxy"].cpu, 512),
+      memory        = try(var.override_autoscaling["fhir-converter-proxy"].memory, 1024),
+      min_capacity  = try(var.override_autoscaling["fhir-converter-proxy"].min_capacity, 1),
+      max_capacity  = try(var.override_autoscaling["fhir-converter-proxy"].max_capacity, 5),
+      target_cpu    = try(var.override_autoscaling["fhir-converter-proxy"].target_cpu, 50),
+      target_memory = try(var.override_autoscaling["fhir-converter-proxy"].target_memory, 80)
+    },
     ingestion = {
       cpu           = try(var.override_autoscaling["ingestion"].cpu, 512),
       memory        = try(var.override_autoscaling["ingestion"].memory, 1024),
@@ -166,6 +174,32 @@ locals {
         }
       ]
     },
+    fhir-converter-proxy = {
+      short_name        = "fhircp",
+      app_repo          = local.dibbs_repo,
+      app_image         = var.disable_ecr == false ? "${terraform.workspace}-fhir-converter-proxy" : "fhir-converter-proxy",
+      app_version       = var.phdi_version,
+      container_port    = 8080,
+      host_port         = 8080,
+      public            = false,
+      registry_url      = local.registry_url,
+      root_service      = false,
+      listener_priority = 50000
+      env_vars = [
+        {
+          name  = "FHIR_CONVERTER_PROXY_PORT",
+          value = "8080"
+        },
+        {
+          name  = "FHIR_CONVERTER_PORT",
+          value = "8080"
+        },
+        {
+          name  = "FHIR_CONVERTER_ECS_NAMESPACE",
+          value = var.cloudmap_namespace_name == "" ? local.local_name : var.cloudmap_namespace_name
+        },
+      ]
+    },
     ingestion = {
       short_name        = "inge",
       app_repo          = local.dibbs_repo,
@@ -251,6 +285,10 @@ locals {
         {
           name  = "FHIR_CONVERTER_URL",
           value = "http://fhir-converter:8080"
+        },
+        {
+          name = "FHIR_CONVERTER_PROXY_URL",
+          value = "http://fhir-converter-proxy:8080"
         },
         {
           name  = "ECR_VIEWER_URL",

--- a/_local.tf
+++ b/_local.tf
@@ -178,7 +178,7 @@ locals {
       short_name        = "fhircp",
       app_repo          = local.dibbs_repo,
       app_image         = var.disable_ecr == false ? "${terraform.workspace}-fhir-converter-proxy" : "fhir-converter-proxy",
-      app_version       = var.phdi_version,
+      app_version       = "0.0.0", #TODO laura: Switch this back
       container_port    = 8080,
       host_port         = 8080,
       public            = false,

--- a/_local.tf
+++ b/_local.tf
@@ -178,7 +178,7 @@ locals {
       short_name        = "fhircp",
       app_repo          = local.dibbs_repo,
       app_image         = var.disable_ecr == false ? "${terraform.workspace}-fhir-converter-proxy" : "fhir-converter-proxy",
-      app_version       = "0.0.1", #TODO laura: Switch this back
+      app_version       = "0.0.2", #TODO laura: Switch this back
       container_port    = 8080,
       host_port         = 8080,
       public            = false,

--- a/_local.tf
+++ b/_local.tf
@@ -178,7 +178,7 @@ locals {
       short_name        = "fhircp",
       app_repo          = local.dibbs_repo,
       app_image         = var.disable_ecr == false ? "${terraform.workspace}-fhir-converter-proxy" : "fhir-converter-proxy",
-      app_version       = "0.0.2", #TODO laura: Switch this back
+      app_version       = var.phdi_version,
       container_port    = 8080,
       host_port         = 8080,
       public            = false,

--- a/ecs.tf
+++ b/ecs.tf
@@ -101,6 +101,14 @@ resource "aws_ecs_service" "this" {
     assign_public_ip = false
   }
 
+  # Dynamically attach the proxy DNS record only for the fhir-converter
+  dynamic "service_registries" {
+    for_each = each.key == "fhir-converter" ? [1] : []
+    content {
+      registry_arn = aws_service_discovery_service.this[each.key].arn
+    }
+  }
+
   service_connect_configuration {
     enabled   = "true"
     namespace = aws_service_discovery_private_dns_namespace.this.arn

--- a/mesh.tf
+++ b/mesh.tf
@@ -44,7 +44,7 @@ resource "aws_appmesh_virtual_node" "this" {
   tags = local.tags
 }
 
-resource "aws_service_discovery_service" "this" {
+/* resource "aws_service_discovery_service" "this" {
   for_each = {
     for key, value in local.service_data : key => value
     if key == "fhir-converter"
@@ -59,4 +59,4 @@ resource "aws_service_discovery_service" "this" {
     }
     routing_policy = "MULTIVALUE"
   }
-}
+} */

--- a/mesh.tf
+++ b/mesh.tf
@@ -44,12 +44,9 @@ resource "aws_appmesh_virtual_node" "this" {
   tags = local.tags
 }
 
-/* resource "aws_service_discovery_service" "this" {
-  for_each = {
-    for key, value in local.service_data : key => value
-    if key == "fhir-converter"
-  }
-  name      = each.key
+resource "aws_service_discovery_service" "this" {
+  for_each = local.service_data
+  name     = each.key
 
   dns_config {
     namespace_id = aws_service_discovery_private_dns_namespace.this.id
@@ -59,4 +56,4 @@ resource "aws_appmesh_virtual_node" "this" {
     }
     routing_policy = "MULTIVALUE"
   }
-} */
+}

--- a/mesh.tf
+++ b/mesh.tf
@@ -49,7 +49,7 @@ resource "aws_service_discovery_service" "this" {
     for key, value in local.service_data : key => value
     if key == "fhir-converter"
   }
-  name      = each.key
+  name = "${each.key}-dns"
 
   dns_config {
     namespace_id = aws_service_discovery_private_dns_namespace.this.id

--- a/mesh.tf
+++ b/mesh.tf
@@ -45,8 +45,11 @@ resource "aws_appmesh_virtual_node" "this" {
 }
 
 resource "aws_service_discovery_service" "this" {
-  for_each = local.service_data
-  name     = each.key
+  for_each = {
+    for key, value in local.service_data : key => value
+    if key == "fhir-converter"
+  }
+  name      = each.key
 
   dns_config {
     namespace_id = aws_service_discovery_private_dns_namespace.this.id

--- a/mesh.tf
+++ b/mesh.tf
@@ -45,19 +45,18 @@ resource "aws_appmesh_virtual_node" "this" {
 }
 
 resource "aws_service_discovery_service" "this" {
-  for_each  = local.service_data
+  for_each = {
+    for key, value in local.service_data : key => value
+    if key == "fhir-converter"
+  }
   name      = each.key
 
-  dynamic "dns_config" {
-    for_each = each.key == "fhir-converter" ? [1] : []
-
-    content {
-      namespace_id = aws_service_discovery_private_dns_namespace.this.id
-      dns_records {
-        ttl  = 10
-        type = "A"
-      }
-      routing_policy = "MULTIVALUE"
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.this.id
+    dns_records {
+      ttl  = 10
+      type = "A"
     }
+    routing_policy = "MULTIVALUE"
   }
 }

--- a/mesh.tf
+++ b/mesh.tf
@@ -43,3 +43,24 @@ resource "aws_appmesh_virtual_node" "this" {
   }
   tags = local.tags
 }
+
+resource "aws_service_discovery_service" "this" {
+  for_each  = local.service_data
+  name      = each.key
+
+  dynamic "dns_config" {
+    for_each = {
+      for key, value in local.service_data : key => value
+      if each.key == "fhir-converter"
+    }
+
+    content {
+      namespace_id = aws_service_discovery_private_dns_namespace.this.id
+      dns_records {
+        ttl  = 10
+        type = "A"
+      }
+      routing_policy = "MULTIVALUE"
+    }
+  }
+}

--- a/mesh.tf
+++ b/mesh.tf
@@ -49,10 +49,7 @@ resource "aws_service_discovery_service" "this" {
   name      = each.key
 
   dynamic "dns_config" {
-    for_each = {
-      for key, value in local.service_data : key => value
-      if each.key == "fhir-converter"
-    }
+    for_each = each.key == "fhir-converter" ? [1] : []
 
     content {
       namespace_id = aws_service_discovery_private_dns_namespace.this.id


### PR DESCRIPTION
## Summary
Adding optional load balancing service that uses HA Proxy to distribute load to the FHIR converters using a "least connections" algorithm to more evenly distribute load vs the built-in Round Robin algorithm used by AWS Service Connect.

See the [FHIR Converter Proxy README](https://github.com/CDCgov/dibbs-ecr-viewer/blob/main/containers/fhir-converter-proxy/README.md) for more details. 